### PR TITLE
Handle content encoding through global configuration.

### DIFF
--- a/docs/examples/code/beautifulsoup_crawler.py
+++ b/docs/examples/code/beautifulsoup_crawler.py
@@ -1,12 +1,15 @@
 import asyncio
 from datetime import timedelta
 
+from crawlee import service_container
 from crawlee.beautifulsoup_crawler import BeautifulSoupCrawler, BeautifulSoupCrawlingContext
 
 
 async def main() -> None:
     # Create an instance of the BeautifulSoupCrawler class, a crawler that automatically
     # loads the URLs and parses their HTML using the BeautifulSoup library.
+    configuration = service_container.get_configuration()
+    configuration.encodings = ('nonsense_encoding', 'cp1252', 'utf-8')
     crawler = BeautifulSoupCrawler(
         # On error, retry each page at most once.
         max_request_retries=1,

--- a/src/crawlee/configuration.py
+++ b/src/crawlee/configuration.py
@@ -30,6 +30,8 @@ class Configuration(BaseSettings):
 
     verbose_log: Annotated[bool, Field(alias='crawlee_verbose_log')] = False
 
+    encodings: Annotated[tuple[str, ...], Field(alias='crawlee_encodings')] = ('utf-8',)
+
     default_browser_path: Annotated[
         str | None,
         Field(


### PR DESCRIPTION
### Description

Web scraping/crawling can dig out text data with different encodings. It might be too hard to reliably guess the correct encoding of the data and so the configuration should offer to the users option to specify recommended encodings.

This change adds encodings to Configuration, which is interpreted as priority ordered list of encodings to be used when needed (For example when saving results to a file.). 
